### PR TITLE
Update README localhost link path and improve readability of font colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ flowchart LR
    yarn dev
    ```
 4. **Open your browser:**
-   Visit [http://localhost:3000](http://localhost:3000) to use the app.
+   Visit [http://localhost:3000/planexplorer](http://localhost:3000/planexplorer) to use the app.
 
 ### Build for Production
 

--- a/src/app/IntervalSelector.module.css
+++ b/src/app/IntervalSelector.module.css
@@ -13,7 +13,7 @@
   flex-direction: column;
   min-width: 0;
   font-weight: 500;
-  color: #222;
+  color: #1f2937;
   margin-bottom: 0;
 }
 
@@ -29,9 +29,11 @@
   border: 1.2px solid #d1d5db;
   padding: 7px 10px;
   font-size: 15px;
-  font-family: monospace;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
   margin-top: 0;
   transition: border 0.2s, background 0.2s;
+  background: #ffffff;
+  color: #1f2937;
 }
 
 .inputFieldInvalid {
@@ -44,8 +46,9 @@
 .intervalInfo {
   margin-top: 12px;
   flex: 1;
-  color: #555;
+  color: #4b5563;
   font-size: 15px;
+  font-weight: 500;
 }
 
 .intervalInfo span {
@@ -69,7 +72,7 @@
 .dimensionLegend {
   font-size: 1rem;
   font-weight: 600;
-  color: #2563eb;
+  color: #1e40af;
   margin-bottom: 0.2em;
   padding: 0 6px;
   line-height: 1.2;

--- a/src/app/ResultList.module.css
+++ b/src/app/ResultList.module.css
@@ -8,6 +8,8 @@
 
 .resultTitle {
   font-weight: 600;
+  color: #1f2937;
+  font-size: 18px;
 }
 
 .resultContent {
@@ -33,30 +35,41 @@
 }
 
 .sql {
-  font-family: monospace;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
   font-size: 15px;
   white-space: pre-wrap;
+  color: #1f2937;
+  background: #f8fafc;
+  padding: 12px;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+  line-height: 1.5;
 }
 
 .noResult {
-  color: #888;
+  color: #6b7280;
   display: block;
+  font-weight: 500;
 }
 
 .noPreparationResult {
-  color: #888;
+  color: #6b7280;
   display: block;
   margin-bottom: 32px;
+  font-weight: 500;
 }
 
 .preparation {
-  font-family: monospace;
-  background: none;
-  padding: 0;
-  border-radius: 0;
-  margin-bottom: 0;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+  background: #f8fafc;
+  padding: 12px;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+  margin-bottom: 12px;
   white-space: pre-wrap;
   word-break: break-word;
+  color: #1f2937;
+  line-height: 1.5;
 }
 
 .preparation:empty {
@@ -78,16 +91,18 @@
 .collapseButton {
   margin: 0 0 8px 0;
   padding: 4px 12px;
-  background: #f3f4f6;
-  border: 1px solid #d1d5db;
+  background: #f8fafc;
+  border: 1px solid #9ca3af;
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.95em;
-  color: #222;
+  color: #1f2937;
+  font-weight: 500;
   transition: background 0.2s;
 }
 .collapseButton:hover {
   background: #e5e7eb;
+  border-color: #6b7280;
 }
 
 .planFingerprintMapBox {
@@ -112,19 +127,22 @@
   padding: 10px 12px;
 }
 .planFingerprintMapPlan {
-  font-family: monospace;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
   font-size: 14px;
-  background: #f8f9fa;
+  background: #ffffff;
   border-radius: 4px;
-  padding: 6px 8px;
+  padding: 8px 10px;
   margin: 6px 0 0 0;
   white-space: pre-wrap;
+  color: #1f2937;
+  border: 1px solid #e2e8f0;
+  line-height: 1.4;
 }
 
 .planUsageCount {
   margin-left: 8px;
-  color: #888;
-  font-weight: 400;
+  color: #6b7280;
+  font-weight: 500;
   font-size: 13px;
 }
 

--- a/src/app/ResultList.tsx
+++ b/src/app/ResultList.tsx
@@ -477,7 +477,7 @@ const PlanFingerprintMapList: React.FC<{ planUsageCount: Record<number, number> 
   };
   return planFingerprintMap.size > 0 ? (
     <div className={styles.planFingerprintMapBox}>
-      <h3><strong>Plan Fingerprints</strong></h3>
+      <h3 className={styles.sectionTitle}><strong>Plan Fingerprints</strong></h3>
       <ul className={styles.planFingerprintMapList}>
         {[...planFingerprintMap.entries()].map(([fingerprint, id]) => (
           <li key={id} className={styles.planFingerprintMapItem}>

--- a/src/app/SqlQueryInput.module.css
+++ b/src/app/SqlQueryInput.module.css
@@ -6,6 +6,8 @@
   font-weight: 600;
   display: block;
   margin-bottom: 8px;
+  color: #1f2937;
+  font-size: 16px;
 }
 
 .sqlTextarea {
@@ -14,24 +16,29 @@
   border: 1.5px solid #d1d5db;
   padding: 12px;
   font-size: 16px;
-  font-family: monospace;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
   resize: vertical;
   margin-bottom: 8px;
   box-sizing: border-box;
+  background: #ffffff;
+  color: #1f2937;
+  line-height: 1.5;
 }
 
 .sqlHint {
-  color: #555;
+  color: #4b5563;
   font-size: 14px;
+  font-weight: 500;
 }
 
 .sqlPlaceholderBtn {
-  background: #f3f4f6;
-  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  border: 1px solid #9ca3af;
   border-radius: 4px;
-  color: #222;
-  font-family: monospace;
+  color: #1f2937;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
   font-size: 14px;
+  font-weight: 600;
   padding: 2px 8px;
   margin: 0 2px;
   cursor: pointer;
@@ -39,7 +46,7 @@
 }
 .sqlPlaceholderBtn:hover {
   background: #e5e7eb;
-  border-color: #a1a1aa;
+  border-color: #6b7280;
 }
 
 .experimentBox {
@@ -57,7 +64,7 @@
 .experimentBox legend {
   font-size: 1rem;
   font-weight: 600;
-  color: #2563eb;
+  color: #1e40af;
   margin-bottom: 0.2em;
   padding: 0 6px;
   line-height: 1.2;

--- a/src/app/SqlQueryInput.module.css
+++ b/src/app/SqlQueryInput.module.css
@@ -32,13 +32,12 @@
 }
 
 .sqlPlaceholderBtn {
-  background: #f9fafb;
-  border: 1px solid #9ca3af;
+  background: #f3f4f6;
+  border: 1px solid #d1d5db;
   border-radius: 4px;
-  color: #1f2937;
-  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+  color: #222;
+  font-family: monospace;
   font-size: 14px;
-  font-weight: 600;
   padding: 2px 8px;
   margin: 0 2px;
   cursor: pointer;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,6 @@ body {
   margin-left: auto;
   margin-right: auto;
   background: #f9f9f9;
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  color: #1f2937;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
 }

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -18,6 +18,7 @@
   font-size: 28px;
   margin-bottom: 32px;
   letter-spacing: 0.5px;
+  color: #1f2937;
 }
 
 .resultBox {


### PR DESCRIPTION
Updates the README localhost link to include the `/planexplorer` path so users following the README will see the app instead of a 404 if they click the link without realizing they need to add the path.

Also updates the font colors to be more legible (and includes some other updates).

All the font color/legibility updates were made via "vibe coding", so I haven't looked into the implementation but just verified that the UI was easier to read in my setup (chrome browser, screenshots below):

Old Top
<img width="745" height="703" alt="image" src="https://github.com/user-attachments/assets/5ffaa8f1-37cb-4707-a7e7-7d5b94f37431" />

New Top
<img width="744" height="691" alt="image" src="https://github.com/user-attachments/assets/0cf250af-1baa-42f0-acab-3cbe2eb86ff2" />

Old Query Plan
<img width="722" height="919" alt="image" src="https://github.com/user-attachments/assets/5080598d-91bd-4a18-af62-64212ad3d65f" />

New Query Plan
<img width="732" height="921" alt="image" src="https://github.com/user-attachments/assets/10044367-6aae-4e54-a2a1-cd1c8456b1d3" />

Old Query Execution Details
<img width="719" height="914" alt="image" src="https://github.com/user-attachments/assets/56935acf-9af7-449d-a545-e11f320cb60b" />

New Query Execution Details
<img width="731" height="912" alt="image" src="https://github.com/user-attachments/assets/cadb7d1d-be4f-449e-b8c9-1706557f531b" />
